### PR TITLE
Modernize URL fields to 2025 standards

### DIFF
--- a/NHTSA_API_Endpoints.md
+++ b/NHTSA_API_Endpoints.md
@@ -20,22 +20,13 @@
 ## Recalls ##
 
 ### End Point ###
-    /Recalls
+    /recalls
 
-### Recalls by Brand ###
-    /Recalls/{PRODUCT_TYPE}/brand/{MAKE}
-    /Recalls/{PRODUCT_TYPE}/brand/{MAKE}/model/{MODEL}
+### Recalls by Vehicle ###
+    /recalls/recallsByVehicle?make={MAKE}&model={MODEL}&modelYear={YEAR}
 
-### Verbose Methods ###
-    /Recalls/{PRODUCT_TYPE}/modelyear/{MODEL_YR}
-    /Recalls/{PRODUCT_TYPE}/modelyear/{MODEL_YR}/make/{MAKE}
-    /Recalls/{PRODUCT_TYPE}/modelyear/{MODEL_YR}/make/{MAKE}/model/{MODEL}
-
-### Concise Methods ###
-    /Recalls/{PRODUCT_TYPE}
-    /Recalls/{PRODUCT_TYPE}/{MODEL_YR}
-    /Recalls/{PRODUCT_TYPE}/{MODEL_YR}/{MAKE}
-    /Recalls/{PRODUCT_TYPE}/{MODEL_YR}/{MAKE}/{MODEL}
+### Recalls by Campaign ###
+    /recalls/campaignNumber?campaignNumber={CAMPAIGN}
 
 
 ## Complaints ##

--- a/lib/nhtsa.rb
+++ b/lib/nhtsa.rb
@@ -10,6 +10,6 @@ module Nhtsa
   require 'json'
   require 'open-uri'
 
-  BASE_URI = "https://api.nhtsa.gov/"
+  BASE_URI = "https://api.nhtsa.gov"
   DEFAULT_PARAMS = "?"
 end

--- a/lib/nhtsa.rb
+++ b/lib/nhtsa.rb
@@ -10,6 +10,6 @@ module Nhtsa
   require 'json'
   require 'open-uri'
 
-  BASE_URI = "https://webapi.nhtsa.gov/api"
-  DEFAULT_PARAMS = "?format=json"
+  BASE_URI = "https://api.nhtsa.gov/"
+  DEFAULT_PARAMS = "?"
 end

--- a/lib/nhtsa/recalls.rb
+++ b/lib/nhtsa/recalls.rb
@@ -8,6 +8,6 @@ require_relative "recalls/campaign_recalls"
 
 module Nhtsa
   module Recalls
-    END_POINT = "/Recalls/vehicle"
+    END_POINT = "/recalls"
   end
 end

--- a/lib/nhtsa/recalls/campaign_recalls.rb
+++ b/lib/nhtsa/recalls/campaign_recalls.rb
@@ -6,7 +6,7 @@ module Nhtsa
       end
 
       def url
-        "#{BASE_URI}#{END_POINT}/CampaignNumber#{DEFAULT_PARAMS}campaignNumber=#{@campaign_number}"
+        "#{BASE_URI}#{END_POINT}/campaignNumber#{DEFAULT_PARAMS}campaignNumber=#{@campaign_number}"
       end
 
       def campaign_recalls

--- a/lib/nhtsa/recalls/campaign_recalls.rb
+++ b/lib/nhtsa/recalls/campaign_recalls.rb
@@ -6,7 +6,7 @@ module Nhtsa
       end
 
       def url
-        "#{BASE_URI}#{END_POINT}/CampaignNumber/#{@campaign_number}#{DEFAULT_PARAMS}"
+        "#{BASE_URI}#{END_POINT}/CampaignNumber#{DEFAULT_PARAMS}campaignNumber=#{@campaign_number}"
       end
 
       def campaign_recalls

--- a/lib/nhtsa/recalls/recalls.rb
+++ b/lib/nhtsa/recalls/recalls.rb
@@ -8,7 +8,7 @@ module Nhtsa
       end
 
       def url
-        "#{BASE_URI}#{END_POINT}/#{@year}/#{@manufacturer}/#{@model}#{DEFAULT_PARAMS}"
+        "#{BASE_URI}#{END_POINT}/recallsByVehicle#{DEFAULT_PARAMS}make=#{@make}&model=#{@model}&modelYear=#{@year}"
       end
 
       def recalls


### PR DESCRIPTION
NHTSA API integration is broken because the URLs and formats have changed. I've tested the new URLs in console, so these should work.